### PR TITLE
Use SSH for private submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,14 +1,14 @@
 [submodule "lib/dnet-p2p"]
 	path = lib/dnet-p2p
-	url = https://github.com/firstbatchxyz/dnet-p2p
+	url = git@github.com:firstbatchxyz/dnet-p2p.git
 	branch = master
 
 [submodule "lib/dperf"]
 	path = lib/dperf
-	url = https://github.com/firstbatchxyz/py-dperf
+	url = git@github.com:firstbatchxyz/py-dperf.git
 	branch = master
 
 [submodule "lib/distilp"]
 	path = lib/distilp
-	url = https://github.com/firstbatchxyz/distilp
+	url = git@github.com:firstbatchxyz/distilp.git
 	branch = master


### PR DESCRIPTION
### Summary
Updates `.gitmodules` to use SSH URLs instead of HTTPS URLs for all private submodules, improving authentication workflow for contributors.

### Motivation
Using SSH URLs eliminates authentication prompts for developers with SSH keys configured and aligns with Git best practices for private repositories.

### Changes

Updated all three submodule URLs from HTTPS to SSH format:

- `lib/dnet-p2p`: `https://github.com/firstbatchxyz/dnet-p2p` → `git@github.com:firstbatchxyz/dnet-p2p.git`
- `lib/dperf`: `https://github.com/firstbatchxyz/py-dperf` → `git@github.com:firstbatchxyz/py-dperf.git`
- `lib/distilp`: `https://github.com/firstbatchxyz/distilp` → `git@github.com:firstbatchxyz/distilp.git`

### Benefits
- No more username/password prompts for SSH-configured users
- More secure authentication via SSH keys
- Standard practice for private repositories
- Smoother developer experience

### Migration for Existing Clones

If you already have the repository cloned, sync the submodule URLs:

```bash
# Sync .gitmodules to .git/config
git submodule sync

# Update submodules with new SSH URLs
git submodule update --init --recursive
```

### Requirements
Contributors need SSH keys configured with GitHub:
- [Generate SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
- [Add to GitHub](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)

This is a one-time setup that benefits all Git operations.