### PR TITLE
CI: Add matrix for ubuntu/macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,15 +25,21 @@ jobs:
 
       - name: Setup SSH agent for submodules
         run: |
-          eval "$(ssh-agent -s)"
-          echo "${{ secrets.CI_SSH_KEY }}" | ssh-add -
           mkdir -p ~/.ssh
+          echo "${{ secrets.CI_SSH_KEY }}" > ~/.ssh/dnet_id_ed25519
+          chmod 600 ~/.ssh/dnet_id_ed25519
           ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git config --global core.sshCommand "ssh -i ~/.ssh/dnet_id_ed25519 -o IdentitiesOnly=yes"
 
       - name: Checkout submodules
         run: |
           git submodule sync --recursive
           git submodule update --init --recursive
+
+      - name: Cleanup SSH key
+        if: always()
+        run: |
+          rm -f ~/.ssh/dnet_id_ed25519
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
## Summary

Refactor CI workflow to use a matrix for both Ubuntu and macOS runners. 

## Motivation

Enable CI testing on both macOS and Ubuntu.

## Changes

- Add matrix strategy for OS: `ubuntu-latest`, `macos-latest`

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] CI/CD improvement

## Testing

- [x] Tests pass locally
- [ ] Added new tests for the changes
- [ ] Existing tests updated

## Checklist

- [x] My code follows the project's code style
- [ ] I have made corresponding changes to the documentation