### PR TITLE
feat: add XGrammar structured output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "dnet-p2p @ file://${PROJECT_ROOT}/lib/dnet-p2p/bindings/py",
   "rich>=13.0.0",
   "psutil>=5.9.0",
+  "xgrammar==0.1.28",   
 ]
 
 [project.optional-dependencies]

--- a/src/dnet/api/models.py
+++ b/src/dnet/api/models.py
@@ -78,7 +78,8 @@ class ChatParams(BaseModel):
     # prediction: NOT USED
     # presence_penalty: float = Field(default=0.0, ge=-2.0, le=2.0)  # NOTE: unused
     # prompt_cache_key: Optional[str] = Field(default=None)  # NOTE: unused
-    # TODO: response_format:
+    response_format: Optional[Union[Dict[str, Any], str]] = Field(default=None)  # For structured outputs (JSON schema)
+    grammar_json_schema: Optional[str] = Field(default=None)  # Direct JSON schema string for grammar-constrained generation
     # safety_identifier: Optional[str] = Field(default=None)  # NOTE: unused
     # service_tier: Optional[str] = Field(default=None)  # NOTE: unused
     stop: Union[str, List[str]] = Field(default_factory=list)

--- a/src/dnet/api/strategies/ring.py
+++ b/src/dnet/api/strategies/ring.py
@@ -175,6 +175,9 @@ class RingApiAdapter(ApiAdapterBase):
             min_tokens_to_keep=decoding_config.min_tokens_to_keep
             if decoding_config
             else 1,
+            grammar_json_schema=decoding_config.grammar_json_schema
+            if decoding_config and hasattr(decoding_config, "grammar_json_schema")
+            else None,
         )
         req = msg.to_proto(tokens)
 

--- a/src/dnet/core/decoding/config.py
+++ b/src/dnet/core/decoding/config.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional, Any
 
 
 @dataclass
@@ -12,3 +13,5 @@ class DecodingConfig:
     logit_bias: dict[int, float] | None = None
     min_p: float = 0.0
     min_tokens_to_keep: int = 1
+    # Structured output support
+    grammar_json_schema: Optional[str] = None  # JSON schema string for grammar-constrained generation

--- a/src/dnet/core/decoding/sampler.py
+++ b/src/dnet/core/decoding/sampler.py
@@ -1,15 +1,69 @@
 import mlx.core as mx
 import numpy as np
+from typing import Optional, Any, Tuple
 from mlx_lm.sample_utils import make_sampler
 from dnet.core.types.messages import TokenResult
 from dnet.core.decoding.config import DecodingConfig
+from dnet.utils.logger import logger
+
+
+class GrammarState:
+    """Holds xgrammar state for a single generation session."""
+    
+    def __init__(self, compiled_grammar, tokenizer_info):
+        import xgrammar as xgr
+        self.compiled_grammar = compiled_grammar
+        self.tokenizer_info = tokenizer_info
+        self.matcher = xgr.GrammarMatcher(compiled_grammar)
+        self.bitmask = None
+        self.vocab_size = tokenizer_info.vocab_size
+    
+    def get_bitmask(self):
+        """Get or create the token bitmask."""
+        if self.bitmask is None:
+            import xgrammar as xgr
+            self.bitmask = xgr.allocate_token_bitmask(1, self.vocab_size)
+        return self.bitmask
 
 
 class Sampler:
     """
     Handles the transformation of logits into tokens based on a DecodingConfig.
     Wraps mlx_lm's make_sampler for consistent sampling behavior.
+    Supports structured output via grammar-constrained generation using xgrammar.
     """
+
+    def __init__(self):
+        """Initialize sampler."""
+        pass
+
+    @staticmethod
+    def create_grammar_state(json_schema: str, tokenizer, model_vocab_size: Optional[int] = None) -> Optional[GrammarState]:
+        """Create a grammar state for JSON schema constrained generation."""
+        if not json_schema:
+            return None
+            
+        try:
+            import xgrammar as xgr
+            
+            vocab_size = model_vocab_size or getattr(tokenizer, 'vocab_size', None)
+            
+            if vocab_size:
+                tokenizer_info = xgr.TokenizerInfo.from_huggingface(tokenizer, vocab_size=vocab_size)
+            else:
+                tokenizer_info = xgr.TokenizerInfo.from_huggingface(tokenizer)
+            
+            grammar_compiler = xgr.GrammarCompiler(tokenizer_info)
+            compiled_grammar = grammar_compiler.compile_json_schema(json_schema)
+            
+            return GrammarState(compiled_grammar, tokenizer_info)
+            
+        except ImportError as e:
+            logger.warning(f"xgrammar not installed: {e}")
+            return None
+        except Exception as e:
+            logger.warning(f"Failed to create grammar state: {e}")
+            return None
 
     @staticmethod
     def sample(
@@ -17,9 +71,11 @@ class Sampler:
         config: DecodingConfig,
         req_logprobs: bool = False,
         req_top_logprobs: int = 0,
+        grammar_state: Optional[GrammarState] = None,
     ) -> TokenResult:
         """
         Sample a token from logits using the provided configuration.
+        If grammar_state is provided, applies grammar constraints before sampling.
         """
         sampler_fn = make_sampler(
             temp=config.temperature,
@@ -38,8 +94,35 @@ class Sampler:
             v = logits[-1]
         else:
             v = logits
+
+        # Apply grammar-constrained logits processing if available
+        if grammar_state is not None:
+            try:
+                import xgrammar as xgr
+                import torch
+                
+                bitmask = grammar_state.get_bitmask()
+                grammar_state.matcher.fill_next_token_bitmask(bitmask)
+                
+                # Convert to float32 first (handles bfloat16 which NumPy doesn't support)
+                # Use buffer protocol instead of .tolist() for better performance
+                v_np = np.array(v.astype(mx.float32))
+                v_torch = torch.from_numpy(v_np).unsqueeze(0)
+                xgr.apply_token_bitmask_inplace(v_torch, bitmask.to(v_torch.device))
+                v = mx.array(v_torch.squeeze(0).numpy())
+                
+            except Exception as e:
+                logger.warning(f"Failed to apply grammar mask: {e}")
+
         token_tensor = sampler_fn(v)
         token_id = int(token_tensor.item())
+        
+        # Update grammar state with accepted token
+        if grammar_state is not None:
+            try:
+                grammar_state.matcher.accept_token(token_id)
+            except Exception as e:
+                logger.warning(f"Failed to accept token in grammar: {e}")
 
         logprob = 0.0
         top_logprobs = {}

--- a/src/dnet/core/types/messages.py
+++ b/src/dnet/core/types/messages.py
@@ -46,6 +46,8 @@ class ActivationMessage:
     repetition_penalty: float = 1.0
     min_p: float = 0.0
     min_tokens_to_keep: int = 1
+    # Structured output support
+    grammar_json_schema: Optional[str] = None  # JSON schema for grammar-constrained generation
 
     @classmethod
     def from_proto(cls, proto_msg: ActivationRequest, pool_id: int = 0):
@@ -74,11 +76,14 @@ class ActivationMessage:
             min_tokens_to_keep=proto_msg.min_tokens_to_keep
             if proto_msg.HasField("min_tokens_to_keep")
             else 1,
+            grammar_json_schema=proto_msg.grammar_json_schema
+            if proto_msg.HasField("grammar_json_schema")
+            else None,
         )
 
     def to_proto(self, data: bytes) -> ActivationRequest:
         """Convert to protobuf request"""
-        return ActivationRequest(
+        req = ActivationRequest(
             nonce=self.nonce,
             activation=Activation(
                 data=data,
@@ -99,6 +104,10 @@ class ActivationMessage:
             min_p=self.min_p,
             min_tokens_to_keep=self.min_tokens_to_keep,
         )
+        # Add optional grammar schema if present
+        if self.grammar_json_schema:
+            req.grammar_json_schema = self.grammar_json_schema
+        return req
 
 
 @dataclass(slots=True)

--- a/src/dnet/protos/dnet_ring.proto
+++ b/src/dnet/protos/dnet_ring.proto
@@ -44,6 +44,9 @@ message ActivationRequest {
     optional float repetition_penalty = 11;
     optional float min_p = 12;
     optional int32 min_tokens_to_keep = 13;
+
+    // Structured output support
+    optional string grammar_json_schema = 14;
 }
 
 // Response message for activation sending

--- a/src/dnet/shard/policies/fit_in_memory.py
+++ b/src/dnet/shard/policies/fit_in_memory.py
@@ -15,6 +15,11 @@ from .base import register_policy, ComputePolicy
 @register_policy("fit")
 class FitInMemoryPolicy(ComputePolicy):
     """Everything fits - no offloading needed"""
+    
+    # Cache grammar states by nonce to maintain state across token generations
+    # TODO: Add TTL-based cleanup for _grammar_states to prevent memory growth
+    # See: _kv_by_nonce pattern in runtime.py
+    _grammar_states: dict = {}
 
     def configure_policy_for_model(self, req: ShardLoadModelRequest) -> None:
         self._mode = "fit"
@@ -138,7 +143,8 @@ class FitInMemoryPolicy(ComputePolicy):
                                 y = self.runtime.model.normalize(x_cast)
                                 y = self.runtime.model.lm_project(y)
 
-                            # Sampling
+                                grammar_schema = getattr(msg, "grammar_json_schema", None)
+                            
                             decoding_config = DecodingConfig(
                                 temperature=msg.temperature,
                                 top_p=msg.top_p,
@@ -146,14 +152,29 @@ class FitInMemoryPolicy(ComputePolicy):
                                 repetition_penalty=msg.repetition_penalty,
                                 min_p=msg.min_p,
                                 min_tokens_to_keep=msg.min_tokens_to_keep,
+                                grammar_json_schema=grammar_schema,
                             )
 
-                            sampler = Sampler()
-                            result = sampler.sample(
+                            # Get or create grammar state (cached by nonce for multi-token generation)
+                            grammar_state = None
+                            if grammar_schema:
+                                nonce = msg.nonce
+                                if nonce in FitInMemoryPolicy._grammar_states:
+                                    grammar_state = FitInMemoryPolicy._grammar_states[nonce]
+                                else:
+                                    tokenizer = getattr(self.runtime, "tokenizer", None)
+                                    model_vocab_size = y.shape[-1] if hasattr(y, 'shape') else None
+                                    if tokenizer:
+                                        grammar_state = Sampler.create_grammar_state(grammar_schema, tokenizer, model_vocab_size)
+                                        if grammar_state:
+                                            FitInMemoryPolicy._grammar_states[nonce] = grammar_state
+                            
+                            result = Sampler.sample(
                                 logits=y,
                                 config=decoding_config,
                                 req_logprobs=msg.req_logprobs,
                                 req_top_logprobs=msg.req_top_logprobs,
+                                grammar_state=grammar_state,
                             )
 
                             token_id = result.token_id


### PR DESCRIPTION
# Pull Request

## Summary

Add structured output support using XGrammar for JSON schema constrained generation.

**Note**: This PR focuses on XGrammar (the faster option mentioned in #45). Open to feedback on adding Outlines support.


## Changes

- Integrate XGrammar for grammar constrained token sampling
- Cache grammar states per nonce for multi token generation
- Load HuggingFace tokenizer on end shard for grammar support
- Optimize MLX→NumPy→Torch conversion using buffer protocol (avoids slow `.tolist()`)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Addresses #45